### PR TITLE
Make format (and optional quality) of uploaded Image configurable.

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -19,7 +19,9 @@ class DefaultController extends Controller
     public function urlToBase64Action(Request $request)
     {
         $image = file_get_contents($request->request->get('url'));
-        $base64 = sprintf('data:image/png;base64,%s', base64_encode($image));
+        $imageInfo = getimagesizefromstring($image);
+        $mimeType = $imageInfo !== false ? $imageInfo['mime'] : 'image/png';
+        $base64 = sprintf('data:' . $mimeType . ';base64,%s', base64_encode($image));
 
         return new JsonResponse([
             'base64' => $base64,

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -101,6 +101,8 @@ class ImageType extends AbstractType
             ->setDefault('enable_locale', true)
             ->setDefault('enable_remote', true)
             ->setDefault('translation_domain', 'PrestaImageBundle')
+            ->setDefault('upload_mimetype', 'image/png')
+            ->setDefault('upload_quality', 0.92);  // default value: https://developer.mozilla.org/de/docs/Web/API/HTMLCanvasElement/toDataURL
         ;
     }
 
@@ -117,6 +119,8 @@ class ImageType extends AbstractType
         $view->vars['preview_height'] = $options['preview_height'];
         $view->vars['enable_locale'] = $options['enable_locale'];
         $view->vars['enable_remote'] = $options['enable_remote'];
+        $view->vars['upload_mimetype'] = $options['upload_mimetype'];
+        $view->vars['upload_quality'] = $options['upload_quality'];
         $view->vars['object'] = $form->getParent()->getData();
 
         if ($options['download_link'] && $view->vars['object']) {

--- a/README.md
+++ b/README.md
@@ -111,13 +111,19 @@ Available options for the `ImageType`:
 - `preview_height` (`int`): the max height to use when displaying the image preview (default: `180`)
 - `download_uri` (`string`): the path where the image is located (default: `null`, automatically set)
 - `download_link` (`bool`): whether the end user should be able to add a remote image by URL (default: `true`)
-
+- `upload_mimetype` (`string`): format of the image to be uploaded (default: `image/png`)  
+  (Note: If choosen mimetype is not supported by browser it will silently fall back to `image/png`)
+- `upload_quality` (`float`): quality (0..1) of uploaded image for lossy imageformats (eg. `image/jpeg`) (default: `0.92`)   
 #### Notes
 
 You can find Cropper options [here](https://github.com/fengyuanchen/cropper#options).
 
 The `max_width` and `max_height` options are used to define maximum size the cropped uploaded image will be.
 Bigger images (after cropping) are scaled down.
+
+**Security Note:** NEVER rely on this size constraints and the format settings as 
+they can be easily manipulated client side. ALWAYS validate the image-data, -size, -format 
+at server side! 
 
 ## Contributing
 

--- a/Resources/public/js/cropper.js
+++ b/Resources/public/js/cropper.js
@@ -198,7 +198,7 @@
         this.$container.$canvas.html(preview_canvas);
 
         // fill input with base64 cropped image
-        this.$input.val(image_canvas.toDataURL());
+        this.$input.val(image_canvas.toDataURL(this.$el.data('mimetype'), this.$el.data('quality')));
 
         // hide the modal
         this.$modal.modal('hide');

--- a/Resources/views/form/image_widget.html.twig
+++ b/Resources/views/form/image_widget.html.twig
@@ -2,7 +2,7 @@
 
 {% block image_widget %}
 {% spaceless %}
-    <div class="cropper" data-cropper-options="{{ form.vars.cropper_options }}" data-max-width="{{ max_width }}" data-max-height="{{ max_height }}">
+    <div class="cropper" data-cropper-options="{{ form.vars.cropper_options }}" data-max-width="{{ max_width }}" data-max-height="{{ max_height }}" data-mimetype="{{ upload_mimetype }}" data-quality="{{ upload_quality }}">
         <div class="cropper-canvas-container{% if form.delete is defined %} cropper-canvas-has-delete{% endif %}" data-preview-width="{{ preview_width }}" data-preview-height="{{ preview_height }}">
             {% if form.vars.download_uri %}
                 <img src="{{ asset(form.vars.download_uri) }}" style="max-width: {{ preview_width }}px; max-height: {{ preview_height }}px;">


### PR DESCRIPTION
This PR lets us define for each upload field individually the format and quality of the uploaded image data. 
It defaults - as before - to `image/png`.

Often there is no need for 100% image quality, most often the source is already an lossy jpeg. This can - depending on the format and quality - save a huge amount of upload-bandwith, especially with photos which most of the time are quite difficult for png to compress effectivly.

As example with my 300x300 sizes testimage, sending the imagedata as for example `image/jpeg` with the default quality of 0.92 resulted in around 30kB of base64 data compared to 230kB PNG base64 data.

As sideeffect it should also fix #25 

As a future PR, there could also be some sort of 'auto' option, chosing the format depending on the source type, depending on your thoughs about it.