### PR TITLE
Bugfix: Correctly strip base64 prefix

### DIFF
--- a/Form/DataTransformer/Base64ToImageTransformer.php
+++ b/Form/DataTransformer/Base64ToImageTransformer.php
@@ -35,8 +35,8 @@ class Base64ToImageTransformer implements DataTransformerInterface
             return null;
         }
 
-
-        $base64 = preg_replace('/data:.*;base64,/', '', $value['base64']);
+        $prefixLenght = strpos($value['base64'], 'base64,') + 7;
+        $base64 = substr($value['base64'], $prefixLenght);
 
         $filePath = tempnam(sys_get_temp_dir(), 'UploadedFile');
         $file = fopen($filePath, 'w');


### PR DESCRIPTION
See original conversation (#33) for thread. Basically this steps away from removing base64 prefix by regex and replace it with php string manipulation.