### PR TITLE
Bugfix: Don't show image if there isn't any

### DIFF
--- a/Resources/views/form/image_widget.html.twig
+++ b/Resources/views/form/image_widget.html.twig
@@ -41,7 +41,7 @@
         </div>
         
         <div class="cropper-canvas-container{% if form.delete is defined %} cropper-canvas-has-delete{% endif %}" data-preview-width="{{ preview_width }}" data-preview-height="{{ preview_height }}">
-            {% if form.vars.download_uri is defined %}
+            {% if form.vars.download_uri is defined and form.vars.download_uri %}
                 <img src="{{ asset(form.vars.download_uri) }}" style="max-width: {{ preview_width }}px; max-height: {{ preview_height }}px;">
             {% endif %}
         </div>


### PR DESCRIPTION
Small fix to don't show image even though `download_uri` is defined. When using Chrome broken images won't be displayed, but when using other browsers an 'broken' image will appear.

This small change in the template will take care of this issue and simply don't output the `<img>` tag when there isn't a `download_uri`