### PR TITLE
Feature: Relatively size save the image

### DIFF
--- a/Resources/public/js/cropper.js
+++ b/Resources/public/js/cropper.js
@@ -172,7 +172,7 @@
      * Create canvas from cropped image and fill in the hidden input with canvas base64 data.
      */
     Cropper.prototype.crop = function() {
-        var data = this.$container.$preview.children('img').cropper('getCropBoxData'),
+        var data = this.$container.$preview.children('img').cropper('getData'),
             image_width = Math.min(this.$el.data('max-width'), data.width),
             image_height = Math.min(this.$el.data('max-height'), data.height),
             preview_width = Math.min(this.$container.$canvas.data('preview-width'), data.width),


### PR DESCRIPTION
We were having some problems with cropping images bigger than the original cropbox.
Say I want to crop an header image, this is a big image (1920x500). Using the ```getCropBoxData``` function; this returns the widht/height of the cropbox itself, not relatively to the image. In this case I always get an image width an max width of 930px because the cropwindow itself is 930. 

This fix fixes this problem by using the ```getData()``` function instead. This function returns the actual data instead of the cropbox data.
https://github.com/fengyuanchen/cropperjs#getdatarounded